### PR TITLE
Git integration with notebooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN chmod +x /tini
 # TODO: investigate
 RUN ln -s /bin/tar/ /bin/gtar
 
-RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@3bf34eb2dbc36ea7f7db131fc41aced8dea79607 && \
     civis-jupyter-notebooks-install
 
 COPY ./setup.R /setup.R

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN chmod +x /tini
 # TODO: investigate
 RUN ln -s /bin/tar/ /bin/gtar
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@2d5d71daa4bc6d66c557a4eaa81a2081090eecf8 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@5ff00365dd4a8b92d261d652693d3d7d3a75141f && \
     civis-jupyter-notebooks-install
 
 COPY ./setup.R /setup.R

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN chmod +x /tini
 # TODO: investigate
 RUN ln -s /bin/tar/ /bin/gtar
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@3bf34eb2dbc36ea7f7db131fc41aced8dea79607 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@be70811509f33e3689a7eeaca15e6db7a706feda && \
     civis-jupyter-notebooks-install
 
 COPY ./setup.R /setup.R

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN chmod +x /tini
 # TODO: investigate
 RUN ln -s /bin/tar/ /bin/gtar
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@be70811509f33e3689a7eeaca15e6db7a706feda && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@4555ee18342a7dfad6fe82cb386303b1d69452d8 && \
     civis-jupyter-notebooks-install
 
 COPY ./setup.R /setup.R

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN chmod +x /tini
 # TODO: investigate
 RUN ln -s /bin/tar/ /bin/gtar
 
-RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@4555ee18342a7dfad6fe82cb386303b1d69452d8 && \
+RUN pip install git+https://github.com/civisanalytics/civis-jupyter-notebook.git@2d5d71daa4bc6d66c557a4eaa81a2081090eecf8 && \
     civis-jupyter-notebooks-install
 
 COPY ./setup.R /setup.R


### PR DESCRIPTION
This branch builds the Docker image for adding git integration with notebooks. It should always point to the latest commit hash in this PR: civisanalytics/civis-jupyter-notebook#14.