### PR TITLE
[CIVP-14972] DEP update civis-r to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [1.4.0] - 2018-01-25
+- Upgraded civis-r to 1.2.0
+
 # [1.3.2] - 2018-01-16
 - Upgraded civis-jupyter-notebook to 0.4.2
 

--- a/setup.R
+++ b/setup.R
@@ -1,6 +1,6 @@
 # Install civis R client
 options(unzip='internal');
-devtools::install_github('civisanalytics/civis-r', ref = 'v1.1.0', upgrade_dependencies = FALSE);
+devtools::install_github('civisanalytics/civis-r', ref = 'v1.2.0', upgrade_dependencies = FALSE);
 
 # Install R Kernel for Jupyter
 install.packages(c('IRdisplay', 'pbdZMQ'))


### PR DESCRIPTION
This PR updates civis-r to 1.2.0, giving notebook users access to CivisML 2.1.