### PR TITLE
[CIVP-17803] [CIVP-17780] 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-# [1.6.0] - 2018-06-21
-- Upgraded civis-r to 1.5.0
+# [1.6.0] - 2019-02-18
+- rocker/verse -> 3.5.2
+- R -> 3.5.2
+- civis-r -> 1.6.1
 
 # [1.5.0] - 2018-05-08
 - Migrate CircleCI build from v1.0 to v2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [1.6.0] - 2018-06-21
+- Upgraded civis-r to 1.5.0
+
 # [1.5.0] - 2018-05-08
 - Migrate CircleCI build from v1.0 to v2.0
 - Upgraded civis-r to 1.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/verse:3.5.0
+FROM rocker/verse:3.5.2
 MAINTAINER support@civisanalytics.com
 
 ENV DEFAULT_KERNEL=ir \
@@ -34,7 +34,8 @@ RUN chmod +x /tini
 # TODO: investigate
 RUN ln -s /bin/tar/ /bin/gtar
 
-RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
+RUN pip install notebook==5.4.1 \
+    civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
     civis-jupyter-notebooks-install
 
 COPY ./setup.R /setup.R

--- a/setup.R
+++ b/setup.R
@@ -1,6 +1,6 @@
 # Install civis R client
 options(unzip='internal');
-devtools::install_github('civisanalytics/civis-r', ref = 'v1.5.0', upgrade_dependencies = FALSE);
+devtools::install_github('civisanalytics/civis-r', ref = 'v1.6.1', upgrade_dependencies = FALSE);
 
 # Install R Kernel for Jupyter
 install.packages(c('IRdisplay', 'pbdZMQ'))

--- a/setup.R
+++ b/setup.R
@@ -1,6 +1,6 @@
 # Install civis R client
 options(unzip='internal');
-devtools::install_github('civisanalytics/civis-r', ref = 'v1.4.0', upgrade_dependencies = FALSE);
+devtools::install_github('civisanalytics/civis-r', ref = 'v1.5.0', upgrade_dependencies = FALSE);
 
 # Install R Kernel for Jupyter
 install.packages(c('IRdisplay', 'pbdZMQ'))


### PR DESCRIPTION
rocker/verse -> 3.5.2
R -> 3.5.2
civis-r -> 1.6.1

`notebook` is pinned to 5.4.1 due to #15.

Closes #15. 

Successfully launched a notebook locally.