### PR TITLE
[CIVP-18029] Update R notebooks to use datascience-python 5.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER support@civisanalytics.com
 
 ENV DEFAULT_KERNEL=ir \
     TINI_VERSION=v0.16.1 \
-    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.4.2
+    CIVIS_JUPYTER_NOTEBOOK_VERSION=0.5.0
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
We need this to complete the bitbucket support for R notebooks. 