### PR TITLE
[CIVP-18712] R -> 3.5.3, civis -> 2.0.0, IRkernel -> 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [1.7.0] - 2019-06-21
+
+### Changed
+
+- rocker/verse -> 3.5.3
+- R -> 3.5.3
+- civis-r -> 2.0.0
+- IRkernel -> 1.0.0
+
 # [1.6.1] - 2019-05-13
 ###Changed
 - civis-jupyter-notebooks v0.4.2 -> v1.0.0 (#18)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/verse:3.5.2
+FROM rocker/verse:3.5.3
 MAINTAINER support@civisanalytics.com
 
 ENV DEFAULT_KERNEL=ir \

--- a/setup.R
+++ b/setup.R
@@ -1,10 +1,10 @@
 # Install civis R client
 options(unzip='internal');
-devtools::install_github('civisanalytics/civis-r', ref = 'v1.6.1', upgrade_dependencies = FALSE);
+devtools::install_github('civisanalytics/civis-r', ref = 'v2.0.0', upgrade_dependencies = FALSE);
 
 # Install R Kernel for Jupyter
 install.packages(c('IRdisplay', 'pbdZMQ'))
-devtools::install_github('IRkernel/IRkernel', ref = '0.7.1', upgrade_dependencies = FALSE);
+devtools::install_github('IRkernel/IRkernel', ref = '1.0.0', upgrade_dependencies = FALSE);
 
 # kernel name = ir
 IRkernel::installspec()


### PR DESCRIPTION
 R -> 3.5.3, 
civis -> 2.0.0, 
IRkernel -> 1.0.0

Successfully tested locally. Note I needed to update `IRkernel` for the local build to work.

Only question is whether this should be a major version bump or not? `civis-r 2.0.0` has breaking changes.