### PR TITLE
1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [1.9.0] - 2020-01-07
+
+### Changed
+
+- datascience-r -> 3.2.0
+- rocker/verse -> 3.6.1
+- 30+ packages added to requirements.txt
+- Geospatial system dependencies
+- Many new packages
+- IRkernel -> 1.0.2
+
 # [1.8.0] - 2019-09-09
 
 ### Changed
@@ -26,7 +37,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - IRkernel -> 1.0.0
 
 # [1.6.1] - 2019-05-13
-###Changed
+
+### Changed
 - civis-jupyter-notebooks v0.4.2 -> v1.0.0 (#18)
 
 # [1.6.0] - 2019-02-18

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/verse:3.6.0
+FROM civisanalytics/datascience-r:3.2.0
 MAINTAINER support@civisanalytics.com
 
 ENV DEFAULT_KERNEL=ir \

--- a/setup.R
+++ b/setup.R
@@ -1,7 +1,3 @@
-# Install civis R client
-options(unzip='internal');
-devtools::install_github('civisanalytics/civis-r', ref = 'v2.1.0', upgrade_dependencies = FALSE);
-
 # Install R Kernel for Jupyter
 install.packages(c('IRdisplay', 'pbdZMQ'))
 devtools::install_github('IRkernel/IRkernel', ref = '1.0.0', upgrade_dependencies = FALSE);

--- a/setup.R
+++ b/setup.R
@@ -1,6 +1,6 @@
 # Install R Kernel for Jupyter
 install.packages(c('IRdisplay', 'pbdZMQ'))
-devtools::install_github('IRkernel/IRkernel', ref = '1.0.0', upgrade_dependencies = FALSE);
+devtools::install_github('IRkernel/IRkernel', ref = '1.0.2')
 
 # kernel name = ir
 IRkernel::installspec()


### PR DESCRIPTION
Upgrade notebooks to new `datascience-r` image. Previously, we inherited from `rocker/verse` and installed `civis` manually again. Instead, we inherit from `datascience-r`.

[Test Notebook](https://platform.civisanalytics.com/spa/#/notebooks/14449?expanded=true)
