### PR TITLE
[SERD-1817] jupyter decode error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [1.10.0] - 2020-01-28
+
+### Fixed
+
+- Decode error when saving R notebooks [SERD-1817]
+
+### Changed
+
+- python2 -> python3.7
+- IRkernel 1.0.2 -> 1.1.0
+
 # [1.9.0] - 2020-01-07
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,26 +5,28 @@ ENV DEFAULT_KERNEL=ir \
     TINI_VERSION=v0.16.1 \
     CIVIS_JUPYTER_NOTEBOOK_VERSION=1.0.1
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -y --no-install-recommends && \
+# for python3.7
+RUN echo 'deb http://ftp.debian.org/debian stable main' >> /etc/apt/sources.list
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y  && \
     apt-get install -y --no-install-recommends \
-        curl \
         wget \
         fonts-dejavu \
         gfortran \
-        python-dev \
         vim \
         nano \
         emacs \
-        gcc &&  \
-    apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+        gcc  \
+        build-essential \
+        python3.7 \
+        python3-pip \
+        python3-setuptools \
+        libcurl3 && \
+        apt-get clean -y && \
+        rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Install pip
-RUN curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python get-pip.py && \
-    pip install --upgrade pip setuptools && \
-    rm -rf ~/.cache/pip && \
-    rm -f get-pip.py
+# instead of virtual env, just use python3.7 as default
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
 
 # Install Tini
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
@@ -34,7 +36,9 @@ RUN chmod +x /tini
 # TODO: investigate
 RUN ln -s /bin/tar/ /bin/gtar
 
-RUN pip install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
+RUN pip3 install wheel && \
+    pip3 install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} \
+      cbor2==4.1.2 && \
     civis-jupyter-notebooks-install
 
 COPY ./setup.R /setup.R

--- a/setup.R
+++ b/setup.R
@@ -1,6 +1,6 @@
 # Install R Kernel for Jupyter
 install.packages(c('IRdisplay', 'pbdZMQ'))
-devtools::install_github('IRkernel/IRkernel', ref = '1.0.2')
+devtools::install_github('IRkernel/IRkernel', ref = '1.1')
 
 # kernel name = ir
 IRkernel::installspec()


### PR DESCRIPTION
Example error:
```
[W 18:24:14.307 NotebookApp] 500 PUT /api/contents/notebook.ipynb?civisuserid=3004&civisusername=pmiller&civisuserorgid=2 (127.0.0.1): Unexpected error while saving file: notebook.ipynb 'ascii' codec can't encode character u'\xd7' in position 29: ordinal not in range(128)
```

I suspect that this had to do with python 2 vs python 3. I did not confirm the root cause.

Changes:
- python2 -> python3.7
- IRkernel 1.0.2 -> IRkernel 1.1 

I went ahead and upgraded to python 3 because python 2 is EOL. It is getting increasingly difficult to work with python 2, and I think it will continue to be less tested. This will enable `civis-jupyter-notebook` to not have to support python 2. This will also enable us to upgrade to python 3 in `datascience-r`.

[Here](https://platform.civisanalytics.com/spa/#/notebooks/14849?expanded=true) is a link to an example notebook on the new image. I performed the same operations in this and in the failing notebook environment, and the errors were not present in the new environment. The notebook appeared to save and load successfully, including after shutdown.
