### PR TITLE
Upgrade civis-jupyter-notebook to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [2.1.0] - 2020-09-09
+
+### Changed
+- civis-jupyter-notebook -> 2.0.0
+
 # [2.0.0] - 2020-08-10
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER support@civisanalytics.com
 
 ENV DEFAULT_KERNEL=ir \
     TINI_VERSION=v0.16.1 \
-    CIVIS_JUPYTER_NOTEBOOK_VERSION=1.0.2
+    CIVIS_JUPYTER_NOTEBOOK_VERSION=2.0.0
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y  && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This PR upgrades the civis-jupyter-notebook package to [v2.0.0](https://github.com/civisanalytics/civis-jupyter-notebook/releases/tag/v2.0.0).  I don't expect any functional changes here, but I'm seeking to bump this repo a minor version so that we don't affect most existing notebooks in Platform, just in case.