### PR TITLE
[CIVIS-3576] [CIVIS-9234] Use the latest datascience-r image and civis-jupyter-notebook release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [3.0.0] - 2024-08-13
+
+### Changed
+- datascience-r -> 6.0.0
+- civis-jupyter-notebook -> 2.2.0
+- tini -> v0.19.0
+
 # [2.2.0] - 2021-04-16
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,6 @@ EXPOSE 8888
 WORKDIR /root/work
 
 ENTRYPOINT ["/tini", "--"]
-CMD ["civis-jupyter-notebooks-start"]
+# Hide the banner about Notebook 7 migration
+# (cf. https://discourse.jupyter.org/t/how-to-disable-message-banner-in-notebook-6-5-4/19422/2)
+CMD ["civis-jupyter-notebooks-start", "--NotebookApp.show_banner=False"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM civisanalytics/datascience-r:4.0.4
-MAINTAINER support@civisanalytics.com
+ARG BUILDPLATFORM=linux/x86_64
+FROM --platform=${BUILDPLATFORM} civisanalytics/datascience-r:6.0.0
+LABEL org.opencontainers.image.authors="support@civisanalytics.com"
 
 ENV DEFAULT_KERNEL=ir \
-    TINI_VERSION=v0.16.1 \
-    CIVIS_JUPYTER_NOTEBOOK_VERSION=2.0.0
+    TINI_VERSION=v0.19.0 \
+    CIVIS_JUPYTER_NOTEBOOK_VERSION=2.2.0
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y  && \
     apt-get install -y --no-install-recommends \
@@ -19,20 +20,14 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y  && \
         apt-get clean -y && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# instead of virtual env, just use python3.7 as default
+# instead of virtual env, just use python3 as default
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
 # Install Tini
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-# needed for some system package
-# TODO: investigate
-RUN ln -s /bin/tar/ /bin/gtar
-
-RUN pip3 install wheel && \
-    pip3 install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} \
-      cbor2==4.1.2 && \
+RUN pip3 install civis-jupyter-notebook==${CIVIS_JUPYTER_NOTEBOOK_VERSION} && \
     civis-jupyter-notebooks-install
 
 COPY ./setup.R /setup.R

--- a/buildspec/merge_master.yaml
+++ b/buildspec/merge_master.yaml
@@ -3,12 +3,12 @@ phases:
   pre_build:
     commands:
       - echo Logging in to Amazon ECR...
-      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${REPOSITORY_URI}
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${FIPS_REPOSITORY_URI}
   build:
     commands:
       - echo Building the Docker image...
-      - docker build -t ${REPOSITORY_URI}:latest .
-      - docker push ${REPOSITORY_URI}:latest
+      - docker build -t ${FIPS_REPOSITORY_URI}:latest .
+      - docker push ${FIPS_REPOSITORY_URI}:latest
   post_build:
     commands:
       - echo Build completed!

--- a/buildspec/merge_master.yaml
+++ b/buildspec/merge_master.yaml
@@ -3,12 +3,12 @@ phases:
   pre_build:
     commands:
       - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${REPOSITORY_URI}
   build:
     commands:
       - echo Building the Docker image...
       - docker build -t ${REPOSITORY_URI}:latest .
-      - docker push ${REPOSITORY_URI}
+      - docker push ${REPOSITORY_URI}:latest
   post_build:
     commands:
       - echo Build completed!

--- a/buildspec/push.yaml
+++ b/buildspec/push.yaml
@@ -14,9 +14,8 @@ phases:
       - docker build --tag ${FIPS_REPOSITORY_URI}:${COMMIT_HASH_SHORT} --tag ${FIPS_REPOSITORY_URI}:${BRANCH_NAME} .
       # This config tests the codebuild login and the build but does not push dev images.
       # The following lines can be temporarily uncommented to test a dev image.
-      # TODO comment these out
-      - docker push ${FIPS_REPOSITORY_URI}:${COMMIT_HASH_SHORT}
-      - docker push ${FIPS_REPOSITORY_URI}:${BRANCH_NAME}
+      # - docker push ${FIPS_REPOSITORY_URI}:${COMMIT_HASH_SHORT}
+      # - docker push ${FIPS_REPOSITORY_URI}:${BRANCH_NAME}
   post_build:
     commands:
       - echo Build completed!

--- a/buildspec/push.yaml
+++ b/buildspec/push.yaml
@@ -3,17 +3,20 @@ phases:
   pre_build:
     commands:
       - echo Logging in to Amazon ECR...
-      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${REPOSITORY_URI}
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${FIPS_REPOSITORY_URI}
       - export COMMIT_HASH_SHORT="$(echo $COMMIT_HASH | cut -c 1-7)"
   build:
     commands:
       - echo Building the Docker image...
-      - echo $REPOSITORY_URI
+      - echo $FIPS_REPOSITORY_URI
       - echo $COMMIT_HASH_SHORT
       - echo $BRANCH_NAME
-      - docker build --tag ${REPOSITORY_URI}:${COMMIT_HASH_SHORT} --tag ${REPOSITORY_URI}:${BRANCH_NAME} .
-      - docker push ${REPOSITORY_URI}:${COMMIT_HASH_SHORT}
-      - docker push ${REPOSITORY_URI}:${BRANCH_NAME}
+      - docker build --tag ${FIPS_REPOSITORY_URI}:${COMMIT_HASH_SHORT} --tag ${FIPS_REPOSITORY_URI}:${BRANCH_NAME} .
+      # This config tests the codebuild login and the build but does not push dev images.
+      # The following lines can be temporarily uncommented to test a dev image.
+      # TODO comment these out
+      - docker push ${FIPS_REPOSITORY_URI}:${COMMIT_HASH_SHORT}
+      - docker push ${FIPS_REPOSITORY_URI}:${BRANCH_NAME}
   post_build:
     commands:
       - echo Build completed!

--- a/buildspec/push.yaml
+++ b/buildspec/push.yaml
@@ -3,7 +3,7 @@ phases:
   pre_build:
     commands:
       - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${REPOSITORY_URI}
       - export COMMIT_HASH_SHORT="$(echo $COMMIT_HASH | cut -c 1-7)"
   build:
     commands:

--- a/buildspec/release.yaml
+++ b/buildspec/release.yaml
@@ -4,7 +4,7 @@ phases:
   pre_build:
     commands:
       - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${REPOSITORY_URI}
   build:
     commands:
       - echo Building the Docker image...
@@ -12,7 +12,7 @@ phases:
       - MINOR_TAG=${PATCH_TAG%.*} # major.minor
       - MAJOR_TAG=${MINOR_TAG%.*} # major
       - docker build -t ${REPOSITORY_URI}:${PATCH_TAG} -t ${REPOSITORY_URI}:${MINOR_TAG} -t ${REPOSITORY_URI}:${MAJOR_TAG} .
-      - docker push ${REPOSITORY_URI}
+      - docker push --all-tags ${REPOSITORY_URI}:${PATCH_TAG}
   post_build:
     commands:
       - echo Build completed!

--- a/buildspec/release.yaml
+++ b/buildspec/release.yaml
@@ -4,15 +4,15 @@ phases:
   pre_build:
     commands:
       - echo Logging in to Amazon ECR...
-      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${REPOSITORY_URI}
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${FIPS_REPOSITORY_URI}
   build:
     commands:
       - echo Building the Docker image...
       - PATCH_TAG=${TAG_NAME#"v"} # major.minor.patch
       - MINOR_TAG=${PATCH_TAG%.*} # major.minor
       - MAJOR_TAG=${MINOR_TAG%.*} # major
-      - docker build -t ${REPOSITORY_URI}:${PATCH_TAG} -t ${REPOSITORY_URI}:${MINOR_TAG} -t ${REPOSITORY_URI}:${MAJOR_TAG} .
-      - docker push --all-tags ${REPOSITORY_URI}:${PATCH_TAG}
+      - docker build -t ${FIPS_REPOSITORY_URI}:${PATCH_TAG} -t ${FIPS_REPOSITORY_URI}:${MINOR_TAG} -t ${FIPS_REPOSITORY_URI}:${MAJOR_TAG} .
+      - docker push --all-tags ${FIPS_REPOSITORY_URI}:${PATCH_TAG}
   post_build:
     commands:
       - echo Build completed!


### PR DESCRIPTION
This updates the Docker image to use the latest datascience-r image and civis-jupyter-notebook release.

It also updates the codebuild configuration, similar to https://github.com/civisanalytics/datascience-r/pull/52.

[Here's](https://platform.civisanalytics.com/spa/#/notebooks/36174?expanded=true) an internal test notebook in Platform.