### PR TITLE
[CIVIS-3576] Fix `release.yaml`

### DIFF
--- a/buildspec/release.yaml
+++ b/buildspec/release.yaml
@@ -12,7 +12,7 @@ phases:
       - MINOR_TAG=${PATCH_TAG%.*} # major.minor
       - MAJOR_TAG=${MINOR_TAG%.*} # major
       - docker build -t ${FIPS_REPOSITORY_URI}:${PATCH_TAG} -t ${FIPS_REPOSITORY_URI}:${MINOR_TAG} -t ${FIPS_REPOSITORY_URI}:${MAJOR_TAG} .
-      - docker push --all-tags ${FIPS_REPOSITORY_URI}:${PATCH_TAG}
+      - docker push --all-tags ${FIPS_REPOSITORY_URI}
   post_build:
     commands:
       - echo Build completed!


### PR DESCRIPTION
This fixes a copy-paste error in `release.yaml` from #33.

(The codebuild run had the error message `tag can't be used with --all-tags/-a`.)