### PR TITLE
[CIVIS-7585] Update civis-jupyter-notebook to fix terminal access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [3.0.1] - 2024-08-15
+
+### Fixed
+- civis-jupyter-notebook -> 2.2.1 to fix terminal access
+
 # [3.0.0] - 2024-08-13
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL org.opencontainers.image.authors="support@civisanalytics.com"
 
 ENV DEFAULT_KERNEL=ir \
     TINI_VERSION=v0.19.0 \
-    CIVIS_JUPYTER_NOTEBOOK_VERSION=2.2.0
+    CIVIS_JUPYTER_NOTEBOOK_VERSION=2.2.1
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y  && \
     apt-get install -y --no-install-recommends \

--- a/buildspec/push.yaml
+++ b/buildspec/push.yaml
@@ -14,8 +14,8 @@ phases:
       - docker build --tag ${FIPS_REPOSITORY_URI}:${COMMIT_HASH_SHORT} --tag ${FIPS_REPOSITORY_URI}:${BRANCH_NAME} .
       # This config tests the codebuild login and the build but does not push dev images.
       # The following lines can be temporarily uncommented to test a dev image.
-      # - docker push ${FIPS_REPOSITORY_URI}:${COMMIT_HASH_SHORT}
-      # - docker push ${FIPS_REPOSITORY_URI}:${BRANCH_NAME}
+      - docker push ${FIPS_REPOSITORY_URI}:${COMMIT_HASH_SHORT}
+      - docker push ${FIPS_REPOSITORY_URI}:${BRANCH_NAME}
   post_build:
     commands:
       - echo Build completed!

--- a/buildspec/push.yaml
+++ b/buildspec/push.yaml
@@ -14,8 +14,8 @@ phases:
       - docker build --tag ${FIPS_REPOSITORY_URI}:${COMMIT_HASH_SHORT} --tag ${FIPS_REPOSITORY_URI}:${BRANCH_NAME} .
       # This config tests the codebuild login and the build but does not push dev images.
       # The following lines can be temporarily uncommented to test a dev image.
-      - docker push ${FIPS_REPOSITORY_URI}:${COMMIT_HASH_SHORT}
-      - docker push ${FIPS_REPOSITORY_URI}:${BRANCH_NAME}
+      # - docker push ${FIPS_REPOSITORY_URI}:${COMMIT_HASH_SHORT}
+      # - docker push ${FIPS_REPOSITORY_URI}:${BRANCH_NAME}
   post_build:
     commands:
       - echo Build completed!


### PR DESCRIPTION
This updates civis-jupyter-notebook to v2.2.1 in order to fix terminal access. See https://github.com/civisanalytics/civis-jupyter-notebook/pull/58.

[Here's](https://platform.civisanalytics.com/spa/#/notebooks/36196?expanded=true) an internal test notebook for this branch. It loaded up fine, and the terminal worked for me.